### PR TITLE
RabbitMQ.Service - Change in PublishReceipt Behavior

### DIFF
--- a/src/HouseofCat.RabbitMQ.Services.Twilio/README.md
+++ b/src/HouseofCat.RabbitMQ.Services.Twilio/README.md
@@ -9,7 +9,7 @@ Set up you appsettings.json
     "TextMessageWorkerService": {
       "ConsumerName": "Text.Message.Consumer",
       "MaxDoP": 4,
-      "From": "+YoPhoneNumber",
+      "From": "+0118-999-881-999-119-725-3",
       "Token": "TwilioToken",
       "Account": "TwilioAccount",
     }

--- a/src/HouseofCat.RabbitMQ/Publisher/Publisher.cs
+++ b/src/HouseofCat.RabbitMQ/Publisher/Publisher.cs
@@ -113,13 +113,13 @@ namespace HouseofCat.RabbitMQ
                 new BoundedChannelOptions(1024)
                 {
                     SingleWriter = false,
-                    SingleReader = true,
+                    SingleReader = false,
+                    FullMode = BoundedChannelFullMode.DropOldest, // never block
                 });
 
             _withHeaders = Options.PublisherOptions.WithHeaders;
             _createPublishReceipts = Options.PublisherOptions.CreatePublishReceipts;
             _waitForConfirmation = TimeSpan.FromMilliseconds(Options.PublisherOptions.WaitForConfirmationTimeoutInMilliseconds);
-
         }
 
         public async Task StartAutoPublishAsync(Func<PublishReceipt, ValueTask> processReceiptAsync = null)

--- a/src/HouseofCat.Utilities/File/StreamValueReader.cs
+++ b/src/HouseofCat.Utilities/File/StreamValueReader.cs
@@ -1,0 +1,26 @@
+﻿using HouseofCat.Utilities.Errors;
+using System;
+using System.Collections.Generic;
+
+namespace HouseofCat.Utilities.File
+{
+    public static class Streaming
+    {
+        public static async IAsyncEnumerable<string> StreamOutStringsAsync(string fileNamePath)
+        {
+            Guard.AgainstNull(fileNamePath, nameof(fileNamePath));
+            if (!System.IO.File.Exists(fileNamePath)) throw new ArgumentException($"{fileNamePath} is not a valid file path.");
+
+            using var streamReader = System.IO.File.OpenText(fileNamePath);
+            string currentLine;
+
+            while ((currentLine = await streamReader.ReadLineAsync().ConfigureAwait(false)) != null)
+            {
+                if (!string.IsNullOrWhiteSpace(currentLine))
+                {
+                    yield return currentLine;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
 * Sacrifice tiny amount of performance on PublishReceipt reading by allowing multiple readers without blocking.
* Add load shedding of oldest receipt, instead of block on publish receipts.

Details on the load shedding were observable behaviors of poorly implemented PublishReceipt handling ended up blocking code. I would rather lose receipts then block users code.

These behaviors are best configurable but that is for a future date resolution across the entire RabbitService.

#4 