### PR TITLE
Allow passing of immediate flag to StopConsumerAsync

### DIFF
--- a/examples/RabbitMQ/ConsumerDataflow/ConsumerDataflow.csproj
+++ b/examples/RabbitMQ/ConsumerDataflow/ConsumerDataflow.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.2.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/RabbitMQ/ConsumerDataflow/Program.cs
+++ b/examples/RabbitMQ/ConsumerDataflow/Program.cs
@@ -59,7 +59,7 @@ namespace Examples.RabbitMQ.ConsumerWorkflow
                 workflowName: workflowName,
                 consumerName: "ConsumerFromConfig",
                 consumerCount: ConsumerCount)
-                .SetSerilizationProvider(_serializationProvider)
+                .SetSerializationProvider(_serializationProvider)
                 .SetEncryptionProvider(_encryptionProvider)
                 .SetCompressionProvider(_compressionProvider)
                 .SetMetricsProvider(_metricsProvider)

--- a/examples/RabbitMQ/ConsumerDataflowMetrics/ConsumerDataflowMetrics.csproj
+++ b/examples/RabbitMQ/ConsumerDataflowMetrics/ConsumerDataflowMetrics.csproj
@@ -34,10 +34,10 @@
 
   <ItemGroup>
     <PackageReference Include="K4os.Compression.LZ4" Version="1.2.6" />
-    <PackageReference Include="prometheus-net" Version="4.1.1" />
-    <PackageReference Include="prometheus-net.AspNetCore" Version="4.1.1" />
+    <PackageReference Include="prometheus-net" Version="4.2.0" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="4.2.0" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.2.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.2" />
   </ItemGroup>
 
 </Project>

--- a/examples/RabbitMQ/ConsumerDataflowMetrics/Services/ConsumerDataflowService.cs
+++ b/examples/RabbitMQ/ConsumerDataflowMetrics/Services/ConsumerDataflowService.cs
@@ -69,7 +69,7 @@ namespace ConsumerDataflowMetrics.Services
                 workflowName: workflowName,
                 consumerName: consumerName,
                 consumerCount: consumerCount)
-                .SetSerilizationProvider(_serializationProvider)
+                .SetSerializationProvider(_serializationProvider)
                 .SetEncryptionProvider(_encryptionProvider)
                 .SetCompressionProvider(_compressionProvider)
                 .SetMetricsProvider(_metricsProvider)

--- a/examples/RabbitMQ/ConsumerPipelineMicroservice/ConsumerPipelineMicroservice.csproj
+++ b/examples/RabbitMQ/ConsumerPipelineMicroservice/ConsumerPipelineMicroservice.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.2.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/RabbitMQ/ConsumerPipelineMicroservice/Program.cs
+++ b/examples/RabbitMQ/ConsumerPipelineMicroservice/Program.cs
@@ -133,7 +133,7 @@ namespace Examples.RabbitMQ.ConsumerPipelineMicroservice
             {
                 var letter = letterTemplate.Clone();
                 letter.Body = JsonSerializer.SerializeToUtf8Bytes(new Message { StringMessage = $"Sensitive ReceivedLetter {i}", MessageId = i });
-                letter.LetterId = (ulong)i;
+                letter.MessageId = Guid.NewGuid().ToString();
                 await rabbitService
                     .Publisher
                     .PublishAsync(letter, true, true)

--- a/examples/RabbitMQ/DataProducer/DataProducer.csproj
+++ b/examples/RabbitMQ/DataProducer/DataProducer.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.2.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/RabbitMQ/DataProducer/Program.cs
+++ b/examples/RabbitMQ/DataProducer/Program.cs
@@ -75,7 +75,7 @@ namespace Examples.RabbitMQ.DataProducer
             {
                 var letter = letterTemplate.Clone();
                 letter.Body = _serializationProvider.Serialize(new Message { StringMessage = $"Sensitive ReceivedLetter {i}", MessageId = i });
-                letter.LetterId = Guid.NewGuid().ToString();
+                letter.MessageId = Guid.NewGuid().ToString();
                 await _rabbitService
                     .Publisher
                     .QueueMessageAsync(letter)

--- a/examples/RabbitMQ/SimpleClient/Program.cs
+++ b/examples/RabbitMQ/SimpleClient/Program.cs
@@ -109,7 +109,7 @@ namespace Examples.RabbitMQ.SimpleClient
             for (ulong i = 0; i < 100; i++)
             {
                 var letter = letterTemplate.Clone();
-                letter.LetterId = Guid.NewGuid().ToString();
+                letter.MessageId = Guid.NewGuid().ToString();
                 var sentMessage = new TestMessage { Message = "Sensitive Message" };
                 sentMessage.Message += $" {i}";
                 letter.Body = JsonSerializer.SerializeToUtf8Bytes(sentMessage);
@@ -135,7 +135,7 @@ namespace Examples.RabbitMQ.SimpleClient
             {
                 var decodedLetter = JsonSerializer.Deserialize<TestMessage>(data.Letter.Body);
 
-                await Console.Out.WriteLineAsync($"LetterId: {data.Letter.GetMessageId()} Received: {decodedLetter.Message}").ConfigureAwait(false);
+                await Console.Out.WriteLineAsync($"LetterId: {data.Letter.MessageId} Received: {decodedLetter.Message}").ConfigureAwait(false);
 
                 // Return true or false to ack / nack the message. Exceptions thrown automatically nack the message.
                 // Strategy would be that you control the retry / permanent error in this method and return true.

--- a/examples/RabbitMQ/StressTestClient/Program.cs
+++ b/examples/RabbitMQ/StressTestClient/Program.cs
@@ -195,9 +195,9 @@ namespace Examples.RabbitMQ.StressAndStabilityConsole
             var sw = Stopwatch.StartNew();
             for (int i = 0; i < count; i++)
             {
-                var letter = RandomData.CreateSimpleRandomLetter(queueName, MessageSize);
+                var letter = MessageExtensions.CreateSimpleRandomLetter(queueName, MessageSize);
                 letter.Envelope.RoutingOptions.DeliveryMode = 1;
-                letter.LetterId = Guid.NewGuid().ToString();
+                letter.MessageId = Guid.NewGuid().ToString();
 
                 await apub.QueueMessageAsync(letter).ConfigureAwait(false);
 
@@ -205,7 +205,7 @@ namespace Examples.RabbitMQ.StressAndStabilityConsole
                 {
                     await Console
                         .Out
-                        .WriteLineAsync($"- QueueName ({queueName}) is publishing letter {letter.LetterId}")
+                        .WriteLineAsync($"- QueueName ({queueName}) is publishing letter {letter.MessageId}")
                         .ConfigureAwait(false);
                 }
             }

--- a/examples/Windows/Windows.NetCoreService/Windows.NetCoreService.csproj
+++ b/examples/Windows/Windows.NetCoreService/Windows.NetCoreService.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="5.0.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HouseofCat.RabbitMQ.Dataflows/ConsumerBlock.cs
+++ b/src/HouseofCat.RabbitMQ.Dataflows/ConsumerBlock.cs
@@ -38,9 +38,9 @@ namespace HouseofCat.RabbitMQ.Dataflows
             _bufferProcessor = PushToBufferAsync(_cts.Token);
         }
 
-        public async Task StopConsumingAsync()
+        public async Task StopConsumingAsync(bool immediate = false)
         {
-            await _consumer.StopConsumerAsync().ConfigureAwait(false);
+            await _consumer.StopConsumerAsync(immediate).ConfigureAwait(false);
             _cts.Cancel();
             await _bufferProcessor.ConfigureAwait(false);
         }

--- a/src/HouseofCat.RabbitMQ.Dataflows/ConsumerDataflow.cs
+++ b/src/HouseofCat.RabbitMQ.Dataflows/ConsumerDataflow.cs
@@ -21,7 +21,6 @@ namespace HouseofCat.RabbitMQ.Dataflows
     {
         public string WorkflowName { get; }
 
-        private readonly ILogger<ConsumerDataflow<TState>> _logger;
         private readonly IRabbitService _rabbitService;
         private readonly ConsumerOptions _consumerOptions;
         private readonly string _consumerName;
@@ -63,7 +62,6 @@ namespace HouseofCat.RabbitMQ.Dataflows
             _consumerCount = consumerCount;
             _consumerName = consumerName;
 
-            _logger = LogHelper.LoggerFactory.CreateLogger<ConsumerDataflow<TState>>();
             _rabbitService = rabbitService;
             _consumerOptions = rabbitService.Options.GetConsumerOptions(consumerName);
             _serializationProvider = rabbitService.SerializationProvider;
@@ -89,11 +87,11 @@ namespace HouseofCat.RabbitMQ.Dataflows
             }
         }
 
-        public async Task StopAsync()
+        public async Task StopAsync(bool immediate = false)
         {
             foreach (var consumerBlock in _consumerBlocks)
             {
-                await consumerBlock.StopConsumingAsync().ConfigureAwait(false);
+                await consumerBlock.StopConsumingAsync(immediate).ConfigureAwait(false);
                 consumerBlock.Complete();
             }
         }

--- a/src/HouseofCat.RabbitMQ.Dataflows/ConsumerDataflow.cs
+++ b/src/HouseofCat.RabbitMQ.Dataflows/ConsumerDataflow.cs
@@ -109,9 +109,9 @@ namespace HouseofCat.RabbitMQ.Dataflows
 
         /// <summary>
         /// Allows you to unset the consumers serialization provider. This will be used when you are not using any serialization on your inner byte payloads.
-        /// <para>By default, the serialization provider will auto-assign the same serialization provider as the one RabbitService uses.</para>
+        /// <para>By default, the serialization provider will auto-assign the same serialization provider (in the Constructor) as the one RabbitService uses.</para>
         /// <para>This is a more exotic scenario where you may be moving plain bytes around.</para>
-        /// <para>ex.) You are transferring data from queue to database and don't need to deserialize the bytes.</para>
+        /// <para>ex.) You are transferring data from queue to database (or other queue) and don't need to deserialize the bytes.</para>
         /// </summary>
         /// <param name="provider"></param>
         /// <returns></returns>

--- a/src/HouseofCat.RabbitMQ.Dataflows/HouseofCat.RabbitMQ.Dataflows.csproj
+++ b/src/HouseofCat.RabbitMQ.Dataflows/HouseofCat.RabbitMQ.Dataflows.csproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\common.props" />
   <PropertyGroup>
-    <Version>1.1.4</Version>
-    <AssemblyVersion>1.1.4</AssemblyVersion>
-    <FileVersion>1.1.4</FileVersion>
+    <Version>1.1.5</Version>
+    <AssemblyVersion>1.1.5</AssemblyVersion>
+    <FileVersion>1.1.5</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\HouseofCat.Compression\HouseofCat.Compression.csproj" />
     <ProjectReference Include="..\HouseofCat.Encryption\HouseofCat.Encryption.csproj" />
-    <ProjectReference Include="..\HouseofCat.Logger\HouseofCat.Logger.csproj" />
     <ProjectReference Include="..\HouseofCat.Metrics\HouseofCat.Metrics.csproj" />
     <ProjectReference Include="..\HouseofCat.RabbitMQ.Services\HouseofCat.RabbitMQ.Services.csproj" />
     <ProjectReference Include="..\HouseofCat.RabbitMQ.WorkState\HouseofCat.RabbitMQ.WorkState.csproj" />

--- a/src/HouseofCat.RabbitMQ.Pipelines/ConsumerPipeline.cs
+++ b/src/HouseofCat.RabbitMQ.Pipelines/ConsumerPipeline.cs
@@ -16,7 +16,7 @@ namespace HouseofCat.RabbitMQ.Pipelines
 
         Task AwaitCompletionAsync();
         Task StartAsync(bool useStream);
-        Task StopAsync();
+        Task StopAsync(bool immediate = false);
     }
 
     public class ConsumerPipeline<TOut> : IConsumerPipeline<TOut>, IDisposable where TOut : RabbitWorkState
@@ -95,7 +95,7 @@ namespace HouseofCat.RabbitMQ.Pipelines
             { _cpLock.Release(); }
         }
 
-        public async Task StopAsync()
+        public async Task StopAsync(bool immediate = false)
         {
             await _cpLock.WaitAsync().ConfigureAwait(false);
 
@@ -106,7 +106,7 @@ namespace HouseofCat.RabbitMQ.Pipelines
                     _cancellationTokenSource.Cancel();
 
                     await Consumer
-                        .StopConsumerAsync(false)
+                        .StopConsumerAsync(immediate)
                         .ConfigureAwait(false);
 
                     if (FeedPipelineWithDataTasks != null)

--- a/src/HouseofCat.RabbitMQ/HouseofCat.RabbitMQ.csproj
+++ b/src/HouseofCat.RabbitMQ/HouseofCat.RabbitMQ.csproj
@@ -20,7 +20,6 @@
     <ProjectReference Include="..\HouseofCat.Reflection\HouseofCat.Reflection.csproj" />
     <ProjectReference Include="..\HouseofCat.Serialization\HouseofCat.Serialization.csproj" />
     <ProjectReference Include="..\HouseofCat.Utilities\HouseofCat.Utilities.csproj" />
-    <ProjectReference Include="..\HouseofCat.Dataflows\HouseofCat.Dataflows.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
With ConsumerPipeline you can get around this to an extent by storing the consumer(s) on creation (but then you can't use the RabbitService helper method). There's no such option with ConsumerDataflow, so I think it's definitely needed there.

Also noticed _logger is unused (only assigned) in ConsumerDataflow so I removed it.