### PR TITLE
Release v4.1.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,7 @@ jobs:
           VERSION_FILE_PATH: version.props
           PROJECT_FILE_PATH: src/HouseofCat.Compression/HouseofCat.Compression.csproj
           INCLUDE_SYMBOLS: true
+          TAG_COMMIT: true
 
     - name: Publish HouseofCat.Data
       uses: alirezanet/publish-nuget@v3.1.0
@@ -49,6 +50,7 @@ jobs:
           VERSION_FILE_PATH: version.props
           PROJECT_FILE_PATH: src/HouseofCat.Data/HouseofCat.Data.csproj
           INCLUDE_SYMBOLS: true
+          TAG_COMMIT: false
 
     - name: Publish HouseofCat.Dataflows
       uses: alirezanet/publish-nuget@v3.1.0
@@ -58,6 +60,7 @@ jobs:
           VERSION_FILE_PATH: version.props
           PROJECT_FILE_PATH: src/HouseofCat.Dataflows/HouseofCat.Dataflows.csproj
           INCLUDE_SYMBOLS: true
+          TAG_COMMIT: false
 
     - name: Publish HouseofCat.Encryption
       uses: alirezanet/publish-nuget@v3.1.0
@@ -67,6 +70,7 @@ jobs:
           VERSION_FILE_PATH: version.props
           PROJECT_FILE_PATH: src/HouseofCat.Encryption/HouseofCat.Encryption.csproj
           INCLUDE_SYMBOLS: true
+          TAG_COMMIT: false
 
     - name: Publish HouseofCat.Hashing
       uses: alirezanet/publish-nuget@v3.1.0
@@ -76,6 +80,7 @@ jobs:
           VERSION_FILE_PATH: version.props
           PROJECT_FILE_PATH: src/HouseofCat.Hashing/HouseofCat.Hashing.csproj
           INCLUDE_SYMBOLS: true
+          TAG_COMMIT: false
 
     - name: Publish HouseofCat.RabbitMQ
       uses: alirezanet/publish-nuget@v3.1.0
@@ -85,6 +90,7 @@ jobs:
           VERSION_FILE_PATH: version.props
           PROJECT_FILE_PATH: src/HouseofCat.RabbitMQ/HouseofCat.RabbitMQ.csproj
           INCLUDE_SYMBOLS: true
+          TAG_COMMIT: false
 
     - name: Publish HouseofCat.Serialization
       uses: alirezanet/publish-nuget@v3.1.0
@@ -94,6 +100,7 @@ jobs:
           VERSION_FILE_PATH: version.props
           PROJECT_FILE_PATH: src/HouseofCat.Serialization/HouseofCat.Serialization.csproj
           INCLUDE_SYMBOLS: true
+          TAG_COMMIT: false
 
     - name: Publish HouseofCat.Utilities
       uses: alirezanet/publish-nuget@v3.1.0
@@ -103,3 +110,4 @@ jobs:
           VERSION_FILE_PATH: version.props
           PROJECT_FILE_PATH: src/HouseofCat.Utilities/HouseofCat.Utilities.csproj
           INCLUDE_SYMBOLS: true
+          TAG_COMMIT: false

--- a/src/HouseofCat.RabbitMQ/Dataflows/ConsumerDataflow.cs
+++ b/src/HouseofCat.RabbitMQ/Dataflows/ConsumerDataflow.cs
@@ -812,6 +812,8 @@ public class ConsumerDataflow<TState> : BaseDataflow<TState>, IConsumerDataflow<
     {
         async Task<TState> WrapPublishAsync(TState state)
         {
+            if (state is null || state.SendMessage is null) return state;
+
             using var childSpan = state.CreateActiveChildSpan(SendStepIdentifier, SpanKind.Producer);
             try
             {

--- a/src/HouseofCat.RabbitMQ/Publisher/Publisher.cs
+++ b/src/HouseofCat.RabbitMQ/Publisher/Publisher.cs
@@ -291,6 +291,7 @@ public class Publisher : IPublisher, IDisposable
                     message.ParentSpanContext ?? default);
 
                 message.Metadata ??= new Metadata();
+                message.Exchange ??= string.Empty;
 
                 // If parent span context is not set, set it to the current span.
                 if (message.ParentSpanContext == default)

--- a/src/HouseofCat.RabbitMQ/Publisher/Publisher.cs
+++ b/src/HouseofCat.RabbitMQ/Publisher/Publisher.cs
@@ -298,17 +298,17 @@ public class Publisher : IPublisher, IDisposable
                     message.ParentSpanContext = span.Context;
                 }
 
-                if (Options.PublisherOptions.Compress)
+                if (Options.PublisherOptions.Compress && !message.Metadata.Compressed())
                 {
-                    message.Body = _compressionProvider.Compress(message.Body).ToArray();
+                    message.Body = _compressionProvider.Compress(message.Body);
                     message.Metadata.Fields[Constants.HeaderForCompressed] = true;
                     message.Metadata.Fields[Constants.HeaderForCompression] = _compressionProvider.Type;
                     span?.AddEvent(_compressEventName);
                 }
 
-                if (Options.PublisherOptions.Encrypt)
+                if (Options.PublisherOptions.Encrypt && !message.Metadata.Encrypted())
                 {
-                    message.Body = _encryptionProvider.Encrypt(message.Body).ToArray();
+                    message.Body = _encryptionProvider.Encrypt(message.Body);
                     message.Metadata.Fields[Constants.HeaderForEncrypted] = true;
                     message.Metadata.Fields[Constants.HeaderForEncryption] = _encryptionProvider.Type;
                     message.Metadata.Fields[Constants.HeaderForEncryptDate] = TimeHelpers.GetDateTimeNow(TimeHelpers.Formats.RFC3339Long);

--- a/src/HouseofCat.RabbitMQ/Publisher/Publisher.cs
+++ b/src/HouseofCat.RabbitMQ/Publisher/Publisher.cs
@@ -506,7 +506,7 @@ public class Publisher : IPublisher, IDisposable
             {
                 using var innerSpan = OpenTelemetryHelpers.StartActiveSpan("IBasicPublishBatch.Add", SpanKind.Producer);
                 EnrichSpanWithTags(span, exchangeName, routingKey);
-                batch.Add(exchangeName, routingKey, mandatory, basicProperties, bodies[i]);
+                batch.Add(exchangeName ?? string.Empty, routingKey, mandatory, basicProperties, bodies[i]);
             }
 
             batch.Publish();
@@ -561,7 +561,7 @@ public class Publisher : IPublisher, IDisposable
                 EnrichSpanWithTags(span, exchangeName, routingKey);
 
                 var properties = BuildProperties(headers, channelHost, null, priority, deliveryMode, contentType);
-                batch.Add(exchangeName, routingKey, mandatory, properties, bodies[i]);
+                batch.Add(exchangeName ?? string.Empty, routingKey, mandatory, properties, bodies[i]);
             }
 
             batch.Publish();
@@ -618,7 +618,7 @@ public class Publisher : IPublisher, IDisposable
             chanHost
                 .Channel
                 .BasicPublish(
-                    message.Exchange,
+                    message.Exchange ?? string.Empty,
                     message.RoutingKey,
                     message.Mandatory,
                     message.BuildProperties(chanHost, withOptionalHeaders, _serializationProvider.ContentType),
@@ -679,7 +679,7 @@ public class Publisher : IPublisher, IDisposable
             chanHost
                 .Channel
                 .BasicPublish(
-                    message.Exchange,
+                    message.Exchange ?? string.Empty,
                     message.RoutingKey,
                     message.Mandatory,
                     message.BuildProperties(chanHost, withOptionalHeaders, _serializationProvider.ContentType),
@@ -745,7 +745,7 @@ public class Publisher : IPublisher, IDisposable
                 innerSpan?.SetAttribute(Constants.MessagingMessageEnvelopeSizeKey, body.Length);
 
                 chanHost.Channel.BasicPublish(
-                    messages[i].Exchange,
+                    messages[i].Exchange ?? string.Empty,
                     messages[i].RoutingKey,
                     messages[i].Mandatory,
                     messages[i].BuildProperties(chanHost, withOptionalHeaders, _serializationProvider.ContentType),
@@ -810,7 +810,7 @@ public class Publisher : IPublisher, IDisposable
                 innerSpan?.SetAttribute(Constants.MessagingMessageEnvelopeSizeKey, body.Length);
 
                 publishBatch.Add(
-                    messages[i].Exchange,
+                    messages[i].Exchange ?? string.Empty,
                     messages[i].RoutingKey,
                     messages[i].Mandatory,
                     messages[i].BuildProperties(chanHost, withOptionalHeaders, _serializationProvider.ContentType),

--- a/tests/RabbitMQ.ConsumerDataflowService/Program.cs
+++ b/tests/RabbitMQ.ConsumerDataflowService/Program.cs
@@ -5,6 +5,7 @@ using HouseofCat.Utilities.Helpers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using RabbitMQ.ConsumerDataflowService;
 using System.Text;
 
@@ -39,7 +40,7 @@ dataflowService.Dataflow.WithCreateSendMessage(
         var message = new Message
         {
             Exchange = "",
-            RoutingKey = state.ReceivedMessage?.Message?.RoutingKey ?? "TestQueue",
+            RoutingKey = dataflowService.Options.SendQueueName,
             Body = Encoding.UTF8.GetBytes("New Secret Message"),
             Metadata = new Metadata
             {

--- a/tests/RabbitMQ.ConsumerDataflowService/Program.cs
+++ b/tests/RabbitMQ.ConsumerDataflowService/Program.cs
@@ -5,7 +5,6 @@ using HouseofCat.Utilities.Helpers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using RabbitMQ.ConsumerDataflowService;
 using System.Text;
 
@@ -37,6 +36,8 @@ dataflowService.AddDefaultErrorHandling();
 dataflowService.Dataflow.WithCreateSendMessage(
     (state) =>
     {
+        if (string.IsNullOrEmpty(dataflowService.Options.SendQueueName)) return state;
+
         var message = new Message
         {
             Exchange = "",

--- a/version.props
+++ b/version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <Version>4.1.3</Version>
-    <AssemblyVersion>4.1.3</AssemblyVersion>
-    <FileVersion>4.1.3</FileVersion>
+    <Version>4.1.4</Version>
+    <AssemblyVersion>4.1.4</AssemblyVersion>
+    <FileVersion>4.1.4</FileVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
 * Fix for double encryption/comrpession.
   * Autopublisher -> error -> ProcessReceipts -> Retry, with PublisherOptions.Encrypt/Compress true, would lead to double encryption/compression.
 * Fix for IMessage publish/re-publish when ExchangeName was `null` vs. `""`. RabbitMQ.Client still errors out when null. This was mostly during Publisher retry errors but is now resolved both in AutoPublishing and direct Publishing.