### PR TITLE
Release v4.1.5

### DIFF
--- a/src/HouseofCat.Dataflows/IWorkState.cs
+++ b/src/HouseofCat.Dataflows/IWorkState.cs
@@ -1,5 +1,4 @@
 ﻿using OpenTelemetry.Trace;
-using System;
 using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
 
@@ -9,16 +8,8 @@ public interface IWorkState
 {
     IDictionary<string, object> Data { get; set; }
 
-    // Routing Logic
-    IDictionary<string, bool> StepSuccess { get; set; }
-    string StepIdentifier { get; set; }
-
-    // Error Handling
     bool IsFaulted { get; set; }
     ExceptionDispatchInfo EDI { get; set; }
-
-    // Outbound
-    ReadOnlyMemory<byte> SendData { get; set; }
 
     // RootSpan or ChildSpan derived from TraceParentHeader
     TelemetrySpan WorkflowSpan { get; set; }

--- a/src/HouseofCat.RabbitMQ/Consumer/Consumer.cs
+++ b/src/HouseofCat.RabbitMQ/Consumer/Consumer.cs
@@ -49,6 +49,8 @@ public class Consumer : IConsumer<IReceivedMessage>, IDisposable
     public IChannelPool ChannelPool { get; }
     public bool Started { get; private set; }
 
+    protected JsonSerializerOptions _defaultOptions;
+
     public Consumer(
         RabbitOptions options,
         string consumerName,
@@ -395,8 +397,6 @@ public class Consumer : IConsumer<IReceivedMessage>, IDisposable
         }
     }
 
-    protected JsonSerializerOptions _defaultOptions;
-
     protected virtual void AutoDeserialize(ReceivedMessage receivedMessage)
     {
         if (receivedMessage.ObjectType == Constants.HeaderValueForMessageObjectType
@@ -407,7 +407,10 @@ public class Consumer : IConsumer<IReceivedMessage>, IDisposable
                 case Constants.HeaderValueForContentTypeJson:
                     try
                     {
-                        receivedMessage.Message = JsonSerializer.Deserialize<Message>(receivedMessage.Body.Span, _defaultOptions);
+                        receivedMessage.Message = JsonSerializer
+                            .Deserialize<Message>(
+                                receivedMessage.Body.Span,
+                                _defaultOptions);
                     }
                     catch
                     { receivedMessage.FailedToDeserialize = true; }
@@ -415,7 +418,9 @@ public class Consumer : IConsumer<IReceivedMessage>, IDisposable
                 case Constants.HeaderValueForContentTypeMessagePack:
                     try
                     {
-                        receivedMessage.Message = MessagePackProvider.GlobalDeserialize<Message>(receivedMessage.Body);
+                        receivedMessage.Message = MessagePackProvider
+                            .GlobalDeserialize<Message>(
+                                receivedMessage.Body);
                     }
                     catch
                     { receivedMessage.FailedToDeserialize = true; }

--- a/src/HouseofCat.RabbitMQ/Consumer/Consumer.cs
+++ b/src/HouseofCat.RabbitMQ/Consumer/Consumer.cs
@@ -411,6 +411,8 @@ public class Consumer : IConsumer<IReceivedMessage>, IDisposable
                             .Deserialize<Message>(
                                 receivedMessage.Body.Span,
                                 _defaultOptions);
+
+                        receivedMessage.Body = default;
                     }
                     catch
                     { receivedMessage.FailedToDeserialize = true; }
@@ -421,6 +423,8 @@ public class Consumer : IConsumer<IReceivedMessage>, IDisposable
                         receivedMessage.Message = MessagePackProvider
                             .GlobalDeserialize<Message>(
                                 receivedMessage.Body);
+
+                        receivedMessage.Body = default;
                     }
                     catch
                     { receivedMessage.FailedToDeserialize = true; }

--- a/src/HouseofCat.RabbitMQ/Dataflows/ConsumerDataflow.cs
+++ b/src/HouseofCat.RabbitMQ/Dataflows/ConsumerDataflow.cs
@@ -20,6 +20,7 @@ namespace HouseofCat.RabbitMQ.Dataflows;
 public interface IConsumerDataflow<TState> where TState : class, IRabbitWorkState, new()
 {
     string WorkflowName { get; }
+    string TimeFormat { get; set; }
 
     TState BuildState(IReceivedMessage receivedMessage);
 
@@ -91,6 +92,8 @@ public class ConsumerDataflow<TState> : BaseDataflow<TState>, IConsumerDataflow<
             return _consumerOptions?.WorkflowName;
         }
     }
+
+    public string TimeFormat { get; set; } = TimeHelpers.Formats.RFC3339Long;
 
     public ConsumerDataflow(
         IRabbitService rabbitService,
@@ -433,7 +436,17 @@ public class ConsumerDataflow<TState> : BaseDataflow<TState>, IConsumerDataflow<
                 executionOptions,
                 false,
                 x => x.ReceivedMessage.Encrypted,
-                GetSpanName("decrypt"));
+                GetSpanName("decrypt"),
+                (state) =>
+                {
+                    if (state?.ReceivedMessage?.Message?.Metadata?.Fields is null) return;
+                    state.ReceivedMessage.Encrypted = false;
+                    state.ReceivedMessage.EncryptionType = null;
+                    state.ReceivedMessage.EncryptedDateTime = default;
+                    state.ReceivedMessage.Message.Metadata.Fields[Constants.HeaderForEncrypted] = false;
+                    state.ReceivedMessage.Message.Metadata.Fields.Remove(Constants.HeaderForEncryption);
+                    state.ReceivedMessage.Message.Metadata.Fields.Remove(Constants.HeaderForEncryptDate);
+                });
         }
         return this;
     }
@@ -454,7 +467,15 @@ public class ConsumerDataflow<TState> : BaseDataflow<TState>, IConsumerDataflow<
                 executionOptions,
                 false,
                 x => x.ReceivedMessage.Compressed,
-                GetSpanName("decompress"));
+                GetSpanName("decompress"),
+                (state) =>
+                {
+                    if (state?.ReceivedMessage?.Message?.Metadata?.Fields is null) return;
+                    state.ReceivedMessage.Compressed = false;
+                    state.ReceivedMessage.CompressionType = null;
+                    state.ReceivedMessage.Message.Metadata.Fields[Constants.HeaderForCompressed] = false;
+                    state.ReceivedMessage.Message.Metadata.Fields.Remove(Constants.HeaderForCompression);
+                });
         }
 
         return this;
@@ -505,8 +526,14 @@ public class ConsumerDataflow<TState> : BaseDataflow<TState>, IConsumerDataflow<
                 _compressionProvider.Compress,
                 executionOptions,
                 true,
-                x => !x.ReceivedMessage.Compressed,
-                GetSpanName("compress send message"));
+                x => !x.SendMessage.Metadata.Compressed(),
+                GetSpanName("compress send message"),
+                (state) =>
+                {
+                    if (state?.SendMessage?.Metadata?.Fields is null) return;
+                    state.SendMessage.Metadata.Fields[Constants.HeaderForCompressed] = true;
+                    state.SendMessage.Metadata.Fields[Constants.HeaderForCompression] = _compressionProvider.Type;
+                });
         }
         return this;
     }
@@ -526,8 +553,15 @@ public class ConsumerDataflow<TState> : BaseDataflow<TState>, IConsumerDataflow<
                 _encryptionProvider.Encrypt,
                 executionOptions,
                 true,
-                x => !x.ReceivedMessage.Encrypted,
-                GetSpanName("encrypt send message"));
+                x => !x.SendMessage.Metadata.Encrypted(),
+                GetSpanName("encrypt send message"),
+                (state) =>
+                {
+                    if (state?.SendMessage?.Metadata?.Fields is null) return;
+                    state.SendMessage.Metadata.Fields[Constants.HeaderForEncrypted] = true;
+                    state.SendMessage.Metadata.Fields[Constants.HeaderForEncryption] = _encryptionProvider.Type;
+                    state.SendMessage.Metadata.Fields[Constants.HeaderForEncryptDate] = TimeHelpers.GetDateTimeNow(TimeFormat);
+                });
         }
         return this;
     }
@@ -714,7 +748,8 @@ public class ConsumerDataflow<TState> : BaseDataflow<TState>, IConsumerDataflow<
         ExecutionDataflowBlockOptions options,
         bool outbound,
         Predicate<TState> predicate,
-        string spanName)
+        string spanName,
+        Action<TState> callback = null)
     {
         TState WrapAction(TState state)
         {
@@ -730,16 +765,17 @@ public class ConsumerDataflow<TState> : BaseDataflow<TState>, IConsumerDataflow<
                 }
                 else if (predicate.Invoke(state))
                 {
-                    if (state.ReceivedMessage.ObjectType == Constants.HeaderValueForMessageObjectType)
+                    if (state.ReceivedMessage.ObjectType == Constants.HeaderValueForMessageObjectType
+                        && state.ReceivedMessage.Message is not null)
                     {
-                        if (state.ReceivedMessage.Message is null)
-                        { state.ReceivedMessage.Message = _serializationProvider.Deserialize<Message>(state.ReceivedMessage.Body); }
-
                         state.ReceivedMessage.Message.Body = action(state.ReceivedMessage.Message.Body);
                     }
                     else
                     { state.ReceivedMessage.Body = action(state.ReceivedMessage.Body); }
                 }
+
+                if (callback is not null)
+                { callback(state); }
             }
             catch (Exception ex)
             {
@@ -761,7 +797,8 @@ public class ConsumerDataflow<TState> : BaseDataflow<TState>, IConsumerDataflow<
         ExecutionDataflowBlockOptions options,
         bool outbound,
         Predicate<TState> predicate,
-        string spanName)
+        string spanName,
+        Action<TState> callback = null)
     {
         async Task<TState> WrapActionAsync(TState state)
         {
@@ -778,16 +815,18 @@ public class ConsumerDataflow<TState> : BaseDataflow<TState>, IConsumerDataflow<
                 }
                 else if (predicate.Invoke(state))
                 {
-                    if (state.ReceivedMessage.ObjectType == Constants.HeaderValueForMessageObjectType)
+                    if (state.ReceivedMessage.ObjectType == Constants.HeaderValueForMessageObjectType
+                        && state.ReceivedMessage.Message is not null)
                     {
-                        if (state.ReceivedMessage.Message is null)
-                        { state.ReceivedMessage.Message = _serializationProvider.Deserialize<Message>(state.ReceivedMessage.Body); }
-
-                        state.ReceivedMessage.Message.Body = await action(state.ReceivedMessage.Message.Body).ConfigureAwait(false);
+                        state.ReceivedMessage.Message.Body = await action(state.ReceivedMessage.Message.Body)
+                            .ConfigureAwait(false);
                     }
                     else
                     { state.ReceivedMessage.Body = await action(state.ReceivedMessage.Body).ConfigureAwait(false); }
                 }
+
+                if (callback is not null)
+                { callback(state); }
             }
             catch (Exception ex)
             {

--- a/src/HouseofCat.RabbitMQ/Dataflows/RabbitWorkState.cs
+++ b/src/HouseofCat.RabbitMQ/Dataflows/RabbitWorkState.cs
@@ -10,8 +10,9 @@ namespace HouseofCat.RabbitMQ.Dataflows;
 public interface IRabbitWorkState : IWorkState
 {
     IReceivedMessage ReceivedMessage { get; set; }
+
+    ReadOnlyMemory<byte> SendData { get; set; }
     IMessage SendMessage { get; set; }
-    bool SendMessageSent { get; set; }
 }
 
 public abstract class RabbitWorkState : IRabbitWorkState
@@ -20,13 +21,10 @@ public abstract class RabbitWorkState : IRabbitWorkState
     public virtual IReceivedMessage ReceivedMessage { get; set; }
 
     public virtual ReadOnlyMemory<byte> SendData { get; set; }
+
     public virtual IMessage SendMessage { get; set; }
-    public virtual bool SendMessageSent { get; set; }
 
     public virtual IDictionary<string, object> Data { get; set; }
-
-    public virtual IDictionary<string, bool> StepSuccess { get; set; }
-    public virtual string StepIdentifier { get; set; }
 
     public bool IsFaulted { get; set; }
     public ExceptionDispatchInfo EDI { get; set; }

--- a/src/HouseofCat.RabbitMQ/Messages/ReceivedMessage.cs
+++ b/src/HouseofCat.RabbitMQ/Messages/ReceivedMessage.cs
@@ -19,12 +19,12 @@ public interface IReceivedMessage
 
     string ObjectType { get; }
 
-    bool Encrypted { get; }
-    string EncryptionType { get; }
-    DateTime EncryptedDateTime { get; }
+    bool Encrypted { get; set; }
+    string EncryptionType { get; set; }
+    DateTime EncryptedDateTime { get; set; }
 
-    bool Compressed { get; }
-    string CompressionType { get; }
+    bool Compressed { get; set; }
+    string CompressionType { get; set; }
 
     public string TraceParentHeader { get; }
     public SpanContext? ParentSpanContext { get; set; }
@@ -52,12 +52,12 @@ public class ReceivedMessage : IReceivedMessage, IDisposable
 
     public string ObjectType { get; private set; }
 
-    public bool Encrypted { get; private set; }
-    public string EncryptionType { get; private set; }
-    public DateTime EncryptedDateTime { get; private set; }
+    public bool Encrypted { get; set; }
+    public string EncryptionType { get; set; }
+    public DateTime EncryptedDateTime { get; set; }
 
-    public bool Compressed { get; private set; }
-    public string CompressionType { get; private set; }
+    public bool Compressed { get; set; }
+    public string CompressionType { get; set; }
 
     public string TraceParentHeader { get; private set; }
     public SpanContext? ParentSpanContext { get; set; }

--- a/src/HouseofCat.RabbitMQ/Services/ConsumerDataflowService.cs
+++ b/src/HouseofCat.RabbitMQ/Services/ConsumerDataflowService.cs
@@ -15,7 +15,7 @@ public interface IConsumerDataflowService<TState> where TState : class, IRabbitW
     void AddErrorHandling(Action<TState> step);
     void AddErrorHandling(Func<TState, Task> step);
 
-    void AddDefaultFinalization(bool log = true);
+    void AddDefaultFinalization();
     void AddFinalization(Action<TState> step);
     void AddFinalization(Func<TState, Task> step);
 
@@ -73,28 +73,9 @@ public class ConsumerDataflowService<TState> : IConsumerDataflowService<TState> 
             Options.WorkflowBatchSize);
     }
 
-    public void AddDefaultFinalization(bool log = true)
+    public void AddDefaultFinalization()
     {
-        _logFinalizationMessage = log;
-
-        Dataflow.WithFinalization(
-            DefaultFinalization,
-            Options.WorkflowMaxDegreesOfParallelism,
-            Options.WorkflowEnsureOrdered,
-            Options.WorkflowBatchSize);
-    }
-
-    protected static readonly string _defaultFinalizationMessage = "Message [{0}] finished processing. Acking message.";
-    private bool _logFinalizationMessage;
-
-    protected void DefaultFinalization(TState state)
-    {
-        if (_logFinalizationMessage)
-        {
-            _logger.LogInformation(_defaultFinalizationMessage, state?.ReceivedMessage?.Message?.MessageId);
-        }
-
-        state?.ReceivedMessage?.AckMessage();
+        Dataflow.WithDefaultErrorHandling();
     }
 
     public void AddFinalization(Action<TState> step)
@@ -135,51 +116,7 @@ public class ConsumerDataflowService<TState> : IConsumerDataflowService<TState> 
 
     public void AddDefaultErrorHandling()
     {
-        Dataflow.WithErrorHandling(
-            DefaultErrorHandlerAsync,
-            Options.WorkflowBatchSize,
-            Options.WorkflowMaxDegreesOfParallelism,
-            Options.WorkflowEnsureOrdered);
-    }
-
-    // First, check if DLQ is configured in QueueArgs.
-    // Second, check if ErrorQueue is set in Options.
-    // Lastly, decide if you want to Nack with requeue, or anything else.
-    protected async Task DefaultErrorHandlerAsync(TState state)
-    {
-        _logger.LogError(state?.EDI?.SourceException, "Error Handler: {0}", state?.EDI?.SourceException?.Message);
-
-        if (Options.RejectOnError())
-        {
-            state.ReceivedMessage?.RejectMessage(requeue: false);
-        }
-        else if (!string.IsNullOrEmpty(Options.ErrorQueueName))
-        {
-            // If type is currently an IMessage, republish with new RoutingKey.
-            if (state.ReceivedMessage.Message is not null)
-            {
-                state.ReceivedMessage.Message.RoutingKey = Options.ErrorQueueName;
-                await _rabbitService.Publisher.QueueMessageAsync(state.ReceivedMessage.Message);
-            }
-            else
-            {
-                await _rabbitService.Publisher.PublishAsync(
-                    exchangeName: "",
-                    routingKey: Options.ErrorQueueName,
-                    body: state.ReceivedMessage.Body,
-                    headers: state.ReceivedMessage.Properties.Headers,
-                    messageId: Guid.NewGuid().ToString(),
-                    deliveryMode: 2,
-                    mandatory: false);
-            }
-
-            // Don't forget to Ack the original message when sending it to a different Queue.
-            state.ReceivedMessage?.AckMessage();
-        }
-        else
-        {
-            state.ReceivedMessage?.NackMessage(requeue: true);
-        }
+        Dataflow.WithDefaultErrorHandling();
     }
 
     public async Task StartAsync()

--- a/src/HouseofCat.RabbitMQ/Services/ConsumerDataflowService.cs
+++ b/src/HouseofCat.RabbitMQ/Services/ConsumerDataflowService.cs
@@ -75,7 +75,7 @@ public class ConsumerDataflowService<TState> : IConsumerDataflowService<TState> 
 
     public void AddDefaultFinalization()
     {
-        Dataflow.WithDefaultErrorHandling();
+        Dataflow.WithDefaultFinalization();
     }
 
     public void AddFinalization(Action<TState> step)

--- a/src/HouseofCat.Serialization/JsonProvider.cs
+++ b/src/HouseofCat.Serialization/JsonProvider.cs
@@ -1,4 +1,5 @@
 ﻿using HouseofCat.Utilities.Errors;
+using HouseofCat.Utilities.Json;
 using System;
 using System.IO;
 using System.Text;
@@ -15,7 +16,12 @@ public class JsonProvider : ISerializationProvider
 
     public JsonProvider(JsonSerializerOptions options = null)
     {
-        _options = options;
+        _options = options ?? new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+        };
+
+        _options.Converters.Add(new FlexibleObjectJsonConverter());
     }
 
     public TOut Deserialize<TOut>(string input)

--- a/tests/RabbitMQ.ConsumerDataflowService/Program.cs
+++ b/tests/RabbitMQ.ConsumerDataflowService/Program.cs
@@ -11,7 +11,7 @@ using System.Text;
 var loggerFactory = LogHelpers.CreateConsoleLoggerFactory(LogLevel.Information);
 LogHelpers.LoggerFactory = loggerFactory;
 var logger = loggerFactory.CreateLogger<Program>();
-var logMessage = false;
+var logMessage = true;
 
 var builder = WebApplication.CreateBuilder(args);
 var configuration = new ConfigurationBuilder()
@@ -59,7 +59,11 @@ dataflowService.AddStep(
     "write_message_to_log",
     (state) =>
     {
-        var message = Encoding.UTF8.GetString(state.ReceivedMessage.Body.Span);
+        string message;
+        if (state.ReceivedMessage.Message is null)
+        { message = Encoding.UTF8.GetString(state.ReceivedMessage.Body.Span); }
+        else
+        { message = Encoding.UTF8.GetString(state.ReceivedMessage.Message.Body.Span); }
         if (message == "throw")
         {
             throw new Exception("Throwing an exception!");

--- a/tests/RabbitMQ.ConsumerDataflowService/RabbitMQ.ConsumerDataflows.json
+++ b/tests/RabbitMQ.ConsumerDataflowService/RabbitMQ.ConsumerDataflows.json
@@ -50,8 +50,8 @@
       "WorkflowBatchSize": 50,
       "WorkflowEnsureOrdered": false,
       "WorkflowWaitForCompletion": false,
-      "WorkflowSendCompressed": false,
-      "WorkflowSendEncrypted": false
+      "WorkflowSendCompressed": true,
+      "WorkflowSendEncrypted": true
     }
   }
 }

--- a/version.props
+++ b/version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <Version>4.1.4</Version>
-    <AssemblyVersion>4.1.4</AssemblyVersion>
-    <FileVersion>4.1.4</FileVersion>
+    <Version>4.1.5</Version>
+    <AssemblyVersion>4.1.5</AssemblyVersion>
+    <FileVersion>4.1.5</FileVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
1. ConsumerDataflow is now able to remove Encrypted/Compress fields from `IReceivedMessage.Message.Metadata` on receipt and processing.
2. ConsumerDataflow is now able to add Encrypted/Compress fields for `SendMessage.Message.Metadata` on receipt and processing.
3. JsonProvider now has DefaultOptions for FlexObject deserialization and property name case insensitive.
4. Removed unused (older) values from IWorkState that were predominantly used when running with by Pipelines.
    1. Other properties were to help step identification for Metrics, that's no longer needed since thats resolved by named spans in OpenTelemetry.